### PR TITLE
Add centralized logging stack with syslog-ng

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-docker log analyser
+# Docker Log Aggregation Stack
+
+This repository provides a simple docker-compose configuration for a centralized logging and monitoring stack. It includes **syslog-ng**, **Prometheus**, **Grafana**, **cAdvisor**, and **Node Exporter**.
+
+## Folder Structure
+
+```
+conf/
+  syslog-ng/syslog-ng.conf       # syslog-ng configuration
+  prometheus/prometheus.yml      # Prometheus scrape configuration
+  grafana/
+    provisioning/
+      datasources/datasource.yml # Grafana datasource for Prometheus
+      dashboards/dashboard.yml   # Dashboard provisioning
+
+logs/
+  syslog-ng/                     # persistent log storage
+
+dashboards/
+  container_overview.json        # sample Grafana dashboard
+```
+
+## Usage
+
+1. Start the stack:
+
+```bash
+docker-compose up -d
+```
+
+2. Send test logs:
+
+```bash
+logger -n 127.0.0.1 -P 514 "test message from host"
+```
+
+3. Access Grafana at [http://localhost:3000](http://localhost:3000) (admin/admin). The `Container Overview` dashboard is preloaded.
+
+4. Prometheus metrics are available at [http://localhost:9090](http://localhost:9090).
+
+Logs collected by syslog-ng are stored under `logs/syslog-ng/`.
+
+## Notes
+
+- Containers are configured with the syslog logging driver to automatically forward their stdout/stderr to syslog-ng.
+- Modify or add dashboards in the `dashboards/` directory and they will be automatically loaded by Grafana.

--- a/conf/grafana/provisioning/dashboards/dashboard.yml
+++ b/conf/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/conf/grafana/provisioning/datasources/datasource.yml
+++ b/conf/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      timeInterval: 15s

--- a/conf/prometheus/prometheus.yml
+++ b/conf/prometheus/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['prometheus:9090']
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']
+  - job_name: 'node_exporter'
+    static_configs:
+      - targets: ['node-exporter:9100']

--- a/conf/syslog-ng/syslog-ng.conf
+++ b/conf/syslog-ng/syslog-ng.conf
@@ -1,0 +1,33 @@
+@version: 3.38
+@include "scl.conf"
+
+options {
+    chain_hostnames(no);
+    stats_freq(0);
+    flush_lines(1);
+    log_msg_size(8192);
+    keep_timestamp(yes);
+};
+
+source s_network_tcp {
+    network(ip(0.0.0.0) port(514) transport("tcp"));
+};
+source s_network_udp {
+    network(ip(0.0.0.0) port(514) transport("udp"));
+};
+
+# Collect docker container logs forwarded via syslog
+source s_docker_logs {
+    syslog();
+};
+
+destination d_local {
+    file("/var/log/syslog-ng/${YEAR}-${MONTH}-${DAY}/${HOST}.log" create_dirs(yes));
+};
+
+log {
+    source(s_network_tcp);
+    source(s_network_udp);
+    source(s_docker_logs);
+    destination(d_local);
+};

--- a/dashboards/container_overview.json
+++ b/dashboards/container_overview.json
@@ -1,0 +1,32 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "type": "graph",
+      "title": "CPU Usage",
+      "targets": [
+        {
+          "expr": "rate(container_cpu_usage_seconds_total{container!='',image!=''}[1m])",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Memory Usage",
+      "targets": [
+        {
+          "expr": "container_memory_usage_bytes{container!='',image!=''}",
+          "legendFormat": "{{pod}}",
+          "refId": "B"
+        }
+      ]
+    }
+  ],
+  "title": "Container Overview",
+  "schemaVersion": 26,
+  "version": 1
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+version: '3.9'
+
+x-logging: &default-logging
+  driver: "syslog"
+  options:
+    syslog-address: "udp://syslog-ng:514"
+    tag: "{{.Name}}"
+
+services:
+  syslog-ng:
+    image: balabit/syslog-ng:latest
+    ports:
+      - "514:514/udp"
+      - "514:514/tcp"
+    volumes:
+      - ./conf/syslog-ng/syslog-ng.conf:/etc/syslog-ng/syslog-ng.conf:ro
+      - ./logs/syslog-ng:/var/log/syslog-ng
+    networks:
+      - logging
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    ports:
+      - "8080:8080"
+    logging: *default-logging
+    networks:
+      - logging
+
+  node-exporter:
+    image: prom/node-exporter:latest
+    ports:
+      - "9100:9100"
+    logging: *default-logging
+    networks:
+      - logging
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./conf/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    depends_on:
+      - cadvisor
+      - node-exporter
+    logging: *default-logging
+    networks:
+      - logging
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./conf/grafana/provisioning:/etc/grafana/provisioning
+      - ./dashboards:/var/lib/grafana/dashboards
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    logging: *default-logging
+    networks:
+      - logging
+
+networks:
+  logging:
+    driver: bridge


### PR DESCRIPTION
## Summary
- introduce docker-compose.yml with syslog-ng, Prometheus, Grafana, cAdvisor and node-exporter
- add syslog-ng configuration
- add Prometheus scrape configuration
- configure Grafana provisioning and a basic dashboard
- update README with usage instructions

## Testing
- `docker-compose config` *(fails: `docker-compose` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621d5e205c8333928ad6240d0c8c05