### PR TITLE
Fix syslog logging address

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ version: '3.9'
 x-logging: &default-logging
   driver: "syslog"
   options:
-    syslog-address: "udp://syslog-ng:514"
+    # The logging driver resolves addresses on the host, so we reference
+    # the syslog-ng service via localhost where port 514 is published.
+    syslog-address: "udp://127.0.0.1:514"
     tag: "{{.Name}}"
 
 services:


### PR DESCRIPTION
## Summary
- configure containers to send logs to syslog-ng via localhost

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686220507df483338b3e28a1d4a88fc9